### PR TITLE
Rest client proxy implementation throws NPE when toString() called

### DIFF
--- a/src/main/java/eu/codearte/resteeth/core/RestClientMethodInterceptor.java
+++ b/src/main/java/eu/codearte/resteeth/core/RestClientMethodInterceptor.java
@@ -2,6 +2,7 @@ package eu.codearte.resteeth.core;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.support.AopUtils;
 
 /**
  * @author Jakub Kubrynski
@@ -16,6 +17,10 @@ class RestClientMethodInterceptor implements MethodInterceptor {
 
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
+		if (AopUtils.isToStringMethod(invocation.getMethod())) {
+			return "Proxy to " + restTemplateInvoker;
+		}
+
 		return restTemplateInvoker.invokeRest(invocation);
 	}
 

--- a/src/test/groovy/eu/codearte/resteeth/core/RestClientMethodInterceptorTest.groovy
+++ b/src/test/groovy/eu/codearte/resteeth/core/RestClientMethodInterceptorTest.groovy
@@ -114,4 +114,13 @@ class RestClientMethodInterceptorTest extends Specification {
 		then:
 			mockServer.verify()
 	}
+
+	def "should not throw when calling toString()"() {
+		when:
+			def str = restClient.toString()
+
+		then:
+			str.startsWith("Proxy to ")
+	}
+
 }


### PR DESCRIPTION
Current implementation of `toString()` in generated proxy throws `NullPointerException`. This fixes it by returning somewhat meaningful message.
