### PR TITLE
Endpoints should return URL rather than String

### DIFF
--- a/src/main/java/eu/codearte/resteeth/endpoint/EndpointProvider.java
+++ b/src/main/java/eu/codearte/resteeth/endpoint/EndpointProvider.java
@@ -1,9 +1,11 @@
 package eu.codearte.resteeth.endpoint;
 
+import java.net.URL;
+
 /**
  * @author Jakub Kubrynski
  */
 public interface EndpointProvider {
 
-	String getEndpoint();
+	URL getEndpoint();
 }

--- a/src/main/java/eu/codearte/resteeth/endpoint/Endpoints.java
+++ b/src/main/java/eu/codearte/resteeth/endpoint/Endpoints.java
@@ -1,5 +1,7 @@
 package eu.codearte.resteeth.endpoint;
 
+import java.net.URL;
+
 /**
  * @author Jakub Kubrynski
  */
@@ -8,11 +10,11 @@ public class Endpoints {
 	private Endpoints() {
 	}
 
-	public static EndpointProvider fixedEndpoint(String endpointUrl) {
+	public static EndpointProvider fixedEndpoint(URL endpointUrl) {
 		return new FixedEndpoint(endpointUrl);
 	}
 
-	public static EndpointProvider roundRobinEndpoint(String... endpointUrls) {
+	public static EndpointProvider roundRobinEndpoint(URL... endpointUrls) {
 		return new RoundRobinEndpoint(endpointUrls);
 	}
 

--- a/src/main/java/eu/codearte/resteeth/endpoint/FixedEndpoint.java
+++ b/src/main/java/eu/codearte/resteeth/endpoint/FixedEndpoint.java
@@ -1,18 +1,20 @@
 package eu.codearte.resteeth.endpoint;
 
+import java.net.URL;
+
 /**
  * @author Jakub Kubrynski
  */
 class FixedEndpoint implements EndpointProvider {
 
-	private final String endpointUrl;
+	private final URL endpointUrl;
 
-	FixedEndpoint(String endpointUrl) {
+	FixedEndpoint(URL endpointUrl) {
 		this.endpointUrl = endpointUrl;
 	}
 
 	@Override
-	public String getEndpoint() {
+	public URL getEndpoint() {
 		return endpointUrl;
 	}
 }

--- a/src/main/java/eu/codearte/resteeth/endpoint/RoundRobinEndpoint.java
+++ b/src/main/java/eu/codearte/resteeth/endpoint/RoundRobinEndpoint.java
@@ -1,5 +1,6 @@
 package eu.codearte.resteeth.endpoint;
 
+import java.net.URL;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -7,15 +8,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 class RoundRobinEndpoint implements EndpointProvider {
 
-	private final String[] endpointUrls;
+	private final URL[] endpointUrls;
 	private final AtomicInteger counter = new AtomicInteger();
 
-	RoundRobinEndpoint(String[] endpointUrls) {
+	RoundRobinEndpoint(URL[] endpointUrls) {
 		this.endpointUrls = endpointUrls;
 	}
 
 	@Override
-	public String getEndpoint() {
+	public URL getEndpoint() {
 		return endpointUrls[Math.abs(counter.getAndIncrement()) % endpointUrls.length];
 	}
 }

--- a/src/test/groovy/eu/codearte/resteeth/core/RestClientMethodInterceptorTest.groovy
+++ b/src/test/groovy/eu/codearte/resteeth/core/RestClientMethodInterceptorTest.groovy
@@ -38,7 +38,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke get method"() {
 		given:
-			mockServer.expect(requestTo("/users/42")).andExpect(method(HttpMethod.GET))
+			mockServer.expect(requestTo("http://localhost/users/42")).andExpect(method(HttpMethod.GET))
 					.andRespond(withSuccess("{ \"id\" : \"42\", \"name\" : \"John\"}", MediaType.APPLICATION_JSON))
 
 		when:
@@ -52,7 +52,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke get method with two parameters"() {
 		given:
-			mockServer.expect(requestTo("/users/42/staff/123")).andExpect(method(HttpMethod.GET))
+			mockServer.expect(requestTo("http://localhost/users/42/staff/123")).andExpect(method(HttpMethod.GET))
 					.andRespond(withSuccess("{ \"id\" : \"42\", \"name\" : \"John\"}", MediaType.APPLICATION_JSON))
 
 		when:
@@ -66,7 +66,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke post method"() {
 		given:
-			mockServer.expect(requestTo("/users")).andExpect(method(HttpMethod.POST))
+			mockServer.expect(requestTo("http://localhost/users")).andExpect(method(HttpMethod.POST))
 					.andExpect(MockRestRequestMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 					.andRespond(withSuccess())
 
@@ -79,7 +79,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke post method with path parameter"() {
 		given:
-			mockServer.expect(requestTo("/users/135/staff")).andExpect(method(HttpMethod.POST))
+			mockServer.expect(requestTo("http://localhost/users/135/staff")).andExpect(method(HttpMethod.POST))
 					.andExpect(MockRestRequestMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 					.andRespond(withCreatedEntity(new URI("http://localhost/users/42")))
 
@@ -92,7 +92,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke put method"() {
 		given:
-			mockServer.expect(requestTo("/users/44")).andExpect(method(HttpMethod.PUT))
+			mockServer.expect(requestTo("http://localhost/users/44")).andExpect(method(HttpMethod.PUT))
 					.andExpect(MockRestRequestMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 					.andRespond(withSuccess())
 
@@ -105,7 +105,7 @@ class RestClientMethodInterceptorTest extends Specification {
 
 	def "should invoke delete method"() {
 		given:
-			mockServer.expect(requestTo("/users/42")).andExpect(method(HttpMethod.DELETE))
+			mockServer.expect(requestTo("http://localhost/users/42")).andExpect(method(HttpMethod.DELETE))
 					.andRespond(withSuccess())
 
 		when:

--- a/src/test/groovy/eu/codearte/resteeth/endpoint/FixedEndpointTest.groovy
+++ b/src/test/groovy/eu/codearte/resteeth/endpoint/FixedEndpointTest.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
  */
 class FixedEndpointTest extends Specification {
 
-	private static final String ENDPOINT_URL = "http://localhost"
+	private static final URL ENDPOINT_URL = "http://localhost".toURL()
 
 	def "should return fixed url"() {
 		given:

--- a/src/test/groovy/eu/codearte/resteeth/endpoint/RoundRobinEndpointTest.groovy
+++ b/src/test/groovy/eu/codearte/resteeth/endpoint/RoundRobinEndpointTest.groovy
@@ -7,8 +7,8 @@ import spock.lang.Specification
  */
 class RoundRobinEndpointTest extends Specification {
 
-	private static final String ENDPOINT_1_URL = "http://localhost1"
-	private static final String ENDPOINT_2_URL = "http://localhost2"
+	private static final URL ENDPOINT_1_URL = "http://localhost1".toURL()
+	private static final URL ENDPOINT_2_URL = "http://localhost2".toURL()
 
 	def "should return fixed url"() {
 		given:

--- a/src/test/groovy/eu/codearte/resteeth/endpoint/StubEndpointProvider.groovy
+++ b/src/test/groovy/eu/codearte/resteeth/endpoint/StubEndpointProvider.groovy
@@ -6,7 +6,7 @@ package eu.codearte.resteeth.endpoint
 class StubEndpointProvider implements EndpointProvider {
 
 	@Override
-	String getEndpoint() {
-		""
+	URL getEndpoint() {
+		new URL("http://localhost")
 	}
 }


### PR DESCRIPTION
It's more descriptive, type safe and catches errors earlier. I decided to leave `String` in `@RestClient` annotation, makes life easier.
